### PR TITLE
Fix issue with PK 1.10.0

### DIFF
--- a/src/me/dreig_michihi/meteordash/MeteorDash.java
+++ b/src/me/dreig_michihi/meteordash/MeteorDash.java
@@ -108,11 +108,11 @@ public class MeteorDash extends CombustionAbility implements AddonAbility {
         fireAuraRadius = ConfigManager.defaultConfig.get().getDouble(path+"FireAuraRadius");
         maxHeightAfterExplosion = player.getLocation().getY();
         hitEntities = new ArrayList();
-        applyModifiers(meteorDamage);
+        setDamage(meteorDamage);
         //location = player.getLocation();
     }
 
-    private void applyModifiers(double damage) {
+    private void setDamage(double damage) {
         int damageMod = 0;
 
         damageMod = (int) (this.getDayFactor(damage) - damage);


### PR DESCRIPTION
Project Korra now has an `applyModifiers()` method in the `FireAbility` class, so I renamed it.

If you want to make a jar that works with pk 1.10.0, you'll have to update the pk jar dependency of course, and also add this jar:
https://search.maven.org/artifact/net.md-5/bungeecord-chat/1.16-R0.4/jar

Downloads -> Jar on the right side 
![image](https://user-images.githubusercontent.com/29555368/188534996-581b226e-3f93-4399-8117-88d791ddd092.png)
